### PR TITLE
Added check to see if 'instances' exist to prevent concatenation error

### DIFF
--- a/FarmLog.lua
+++ b/FarmLog.lua
@@ -801,8 +801,10 @@ function FarmLog_MainWindow:Refresh()
 		self:AddRow(GetSessionVar("xp").." "..L["XP"], nil, nil, TEXT_COLOR["xp"]) 
 	end 
 	if GetSessionVar("resets") > 0 then 
-		self:AddRow(GetSessionVar("resets").." "..L["instances"], nil, nil, TEXT_COLOR["xp"]) 
-	end 
+		if instances then
+			self:AddRow(GetSessionVar("resets").." "..L["instances"], nil, nil, TEXT_COLOR["xp"]) 
+		end
+	end
 	for faction, rep in pairs(GetSessionVar("rep")) do 
 		self:AddRow(rep.." "..faction.." "..L["reputation"], nil, nil, TEXT_COLOR["rep"]) 
 	end 


### PR DESCRIPTION
Tracked down the issue of no mobs or items being displayed at all in the log. If instances does not exist it is causing a concatenation error which leads to none of the items or mobs killed to be displayed. Seems to be an issue for a some people on curseforge.